### PR TITLE
Github functionality broken -- please read.

### DIFF
--- a/src/lovely/buildouthttp/buildouthttp.py
+++ b/src/lovely/buildouthttp/buildouthttp.py
@@ -70,7 +70,8 @@ class GithubHandler(urllib2.BaseHandler):
             timeout = getattr(req, 'timeout', 60)
             if hasattr(req, 'timeout'):
                 timeout = req.timeout
-            req = urllib2.Request(req.get_full_url(), data)
+            full_url = '%s?%s' % (req.get_full_url(), data)
+            req = urllib2.Request(full_url)
             req.timeout = timeout
         return req
 


### PR DESCRIPTION
Private repository pulls from GitHub broke on me on Friday (or it might have been Thursday); I spent hours trying to figure out what went wrong.

I finally figured out that POST request for authentication to github private repositories is no longer supported at all; you get a helpful 422 error code if you try.

This change alters authentication to use GET instead of POST and I can confirm it works again. All unit tests passing for me.
