### PR TITLE
Add user agent for github

### DIFF
--- a/src/lovely/buildouthttp/buildouthttp.py
+++ b/src/lovely/buildouthttp/buildouthttp.py
@@ -163,7 +163,8 @@ class GithubHandler(urllib2.BaseHandler):
                 req = urllib2.Request(new_url)
                 req.timeout = timeout
                 # Re-add user-agent, as the GitHub API requires this for auth
-                req.add_header('user-agent', old_req.headers['user-agent'])
+                req.add_header('user-agent', old_req.get_header('user-agent',
+                                                            'Python-urllib2'))
             else:
                 log.debug("Github url %r blocked by buildout.github-repos" %
                           (url,))


### PR DESCRIPTION
The GitHub API now requires the useragent to always be set, and as lovely.buildouthttp creates a new request when it adds auth details we lose that header, this patch adds it back in from the old request object.

See for more info on the API change: http://developer.github.com/changes/2013-04-24-user-agent-required/
